### PR TITLE
accurately calculate available screen space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 /Makefile
 /TODO.md
+/neovim

--- a/compleet-client/src/autocmds/augroup.rs
+++ b/compleet-client/src/autocmds/augroup.rs
@@ -76,12 +76,12 @@ impl Augroup {
                     _,
                     _,
                     _,
-                    u32,
+                    u16,
                     _,
-                    u32,
+                    u16,
                     _,
                     _,
-                    u32,
+                    u16,
                     _,
                 )| {
                     channel::on_bytes(
@@ -125,7 +125,7 @@ impl Augroup {
     pub fn clear_local(&self, lua: &Lua, buffer: &Buffer) -> LuaResult<()> {
         api::clear_autocmds(
             lua,
-            lua.create_table_from([("buffer", buffer.bufnr)])?,
+            lua.create_table_from([("buffer", buffer.number)])?,
         )
     }
 
@@ -176,7 +176,7 @@ impl Augroup {
             let opts = lua.create_table_from([
                 ("group", LuaValue::Integer(id as i64)),
                 ("callback", LuaValue::Function(callback)),
-                ("buffer", LuaValue::Integer(buffer.bufnr as i64)),
+                ("buffer", LuaValue::Integer(buffer.number as i64)),
             ])?;
 
             api::create_autocmd(lua, vec![event], opts)?;

--- a/compleet-client/src/autocmds/augroup.rs
+++ b/compleet-client/src/autocmds/augroup.rs
@@ -10,7 +10,7 @@ use crate::{bindings::api, constants::AUGROUP_NAME, ui::Buffer};
 #[derive(Debug, Default)]
 pub struct Augroup {
     /// The augroup id returned by `vim.api.nvim_create_autocmd`.
-    id: Option<u32>,
+    id: Option<u16>,
 
     /// The registry key of the Lua function called on `BufEnter` to try to
     /// attach to the buffer.
@@ -125,7 +125,7 @@ impl Augroup {
     pub fn clear_local(&self, lua: &Lua, buffer: &Buffer) -> LuaResult<()> {
         api::clear_autocmds(
             lua,
-            lua.create_table_from([("buffer", buffer.number)])?,
+            lua.create_table_from([("buffer", buffer.bufnr)])?,
         )
     }
 
@@ -176,7 +176,7 @@ impl Augroup {
             let opts = lua.create_table_from([
                 ("group", LuaValue::Integer(id as i64)),
                 ("callback", LuaValue::Function(callback)),
-                ("buffer", LuaValue::Integer(buffer.number as i64)),
+                ("buffer", LuaValue::Integer(buffer.bufnr as i64)),
             ])?;
 
             api::create_autocmd(lua, vec![event], opts)?;

--- a/compleet-client/src/bindings/api/autocmd.rs
+++ b/compleet-client/src/bindings/api/autocmd.rs
@@ -11,7 +11,7 @@ pub fn clear_autocmds(lua: &Lua, opts: Table) -> LuaResult<()> {
 }
 
 /// Binding to `vim.api.nvim_create_augroup`.
-pub fn create_augroup(lua: &Lua, name: &str, opts: Table) -> LuaResult<u32> {
+pub fn create_augroup(lua: &Lua, name: &str, opts: Table) -> LuaResult<u16> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_create_augroup")?
         .call((name, opts))
@@ -22,7 +22,7 @@ pub fn create_autocmd<S: AsRef<str>, E: IntoIterator<Item = S>>(
     lua: &Lua,
     events: E,
     opts: Table,
-) -> LuaResult<u32> {
+) -> LuaResult<u16> {
     let events =
         events.into_iter().map(|e| e.as_ref().into()).collect::<Vec<String>>();
 
@@ -32,7 +32,7 @@ pub fn create_autocmd<S: AsRef<str>, E: IntoIterator<Item = S>>(
 }
 
 /// Binding to `vim.api.nvim_del_augroup_by_id`.
-pub fn del_augroup_by_id(lua: &Lua, id: u32) -> LuaResult<()> {
+pub fn del_augroup_by_id(lua: &Lua, id: u16) -> LuaResult<()> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_del_augroup_by_id")?
         .call(id)
@@ -48,7 +48,7 @@ pub fn del_augroup_by_name(lua: &Lua, name: &str) -> LuaResult<()> {
 
 #[allow(dead_code)]
 /// Binding to `vim.api.nvim_del_autocmd`.
-pub fn del_autocmd(lua: &Lua, id: u32) -> LuaResult<()> {
+pub fn del_autocmd(lua: &Lua, id: u16) -> LuaResult<()> {
     super::api(lua)?.get::<&str, LuaFunction>("nvim_del_autocmd")?.call(id)
 }
 

--- a/compleet-client/src/bindings/api/buffer.rs
+++ b/compleet-client/src/bindings/api/buffer.rs
@@ -31,7 +31,7 @@ pub fn buf_call(lua: &Lua, bufnr: u16, fun: LuaFunction) -> LuaResult<()> {
 pub fn buf_get_lines(
     lua: &Lua,
     bufnr: u16,
-    start: u32,
+    start: i32,
     end: i32,
     strict_indexing: bool,
 ) -> LuaResult<Vec<String>> {
@@ -58,7 +58,7 @@ pub fn buf_get_option<'lua, V: FromLua<'lua>>(
 pub fn buf_set_lines(
     lua: &Lua,
     bufnr: u16,
-    start: u32,
+    start: i32,
     end: i32,
     strict_indexing: bool,
     replacement: Vec<String>,
@@ -76,10 +76,10 @@ pub fn buf_set_lines(
 pub fn buf_set_text(
     lua: &Lua,
     bufnr: u16,
-    start_row: u32,
-    start_col: u32,
-    end_row: u32,
-    end_col: u32,
+    start_row: u16,
+    start_col: u16,
+    end_row: u16,
+    end_col: u16,
     replacement: Vec<String>,
 ) -> LuaResult<()> {
     super::api(lua)?.get::<&str, LuaFunction>("nvim_buf_set_text")?.call((

--- a/compleet-client/src/bindings/api/buffer.rs
+++ b/compleet-client/src/bindings/api/buffer.rs
@@ -8,7 +8,7 @@ use mlua::{
 /// Binding to `vim.api.nvim_buf_attach`.
 pub fn buf_attach(
     lua: &Lua,
-    bufnr: u32,
+    bufnr: u16,
     send_buffer: bool,
     opts: Table,
 ) -> LuaResult<bool> {
@@ -21,7 +21,7 @@ pub fn buf_attach(
 
 #[allow(dead_code)]
 /// Binding to `vim.api.nvim_buf_call`.
-pub fn buf_call(lua: &Lua, bufnr: u32, fun: LuaFunction) -> LuaResult<()> {
+pub fn buf_call(lua: &Lua, bufnr: u16, fun: LuaFunction) -> LuaResult<()> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_buf_call")?
         .call((bufnr, fun))
@@ -30,7 +30,7 @@ pub fn buf_call(lua: &Lua, bufnr: u32, fun: LuaFunction) -> LuaResult<()> {
 /// Binding to `vim.api.nvim_buf_get_lines`.
 pub fn buf_get_lines(
     lua: &Lua,
-    bufnr: u32,
+    bufnr: u16,
     start: u32,
     end: i32,
     strict_indexing: bool,
@@ -46,7 +46,7 @@ pub fn buf_get_lines(
 /// Binding to `vim.api.nvim_buf_get_lines`.
 pub fn buf_get_option<'lua, V: FromLua<'lua>>(
     lua: &'lua Lua,
-    bufnr: u32,
+    bufnr: u16,
     name: &str,
 ) -> LuaResult<V> {
     super::api(lua)?
@@ -57,7 +57,7 @@ pub fn buf_get_option<'lua, V: FromLua<'lua>>(
 /// Binding to `vim.api.nvim_buf_set_lines`.
 pub fn buf_set_lines(
     lua: &Lua,
-    bufnr: u32,
+    bufnr: u16,
     start: u32,
     end: i32,
     strict_indexing: bool,
@@ -75,7 +75,7 @@ pub fn buf_set_lines(
 /// Binding to `vim.api.nvim_buf_set_text`.
 pub fn buf_set_text(
     lua: &Lua,
-    bufnr: u32,
+    bufnr: u16,
     start_row: u32,
     start_col: u32,
     end_row: u32,

--- a/compleet-client/src/bindings/api/extmark.rs
+++ b/compleet-client/src/bindings/api/extmark.rs
@@ -36,8 +36,8 @@ pub fn buf_set_extmark(
     lua: &Lua,
     bufnr: u16,
     ns_id: u16,
-    row: u32,
-    col: u32,
+    row: u16,
+    col: u16,
     opts: Table,
 ) -> LuaResult<u16> {
     super::api(lua)?

--- a/compleet-client/src/bindings/api/extmark.rs
+++ b/compleet-client/src/bindings/api/extmark.rs
@@ -6,7 +6,7 @@ use mlua::{
 /// Binding to `vim.api.nvim_buf_add_highlight`.
 pub fn buf_add_highlight(
     lua: &Lua,
-    bufnr: u32,
+    bufnr: u16,
     ns_id: i32,
     hl_group: String,
     line: u32,
@@ -21,7 +21,7 @@ pub fn buf_add_highlight(
 /// Binding to `vim.api.nvim_buf_clear_namespace`.
 pub fn buf_clear_namespace(
     lua: &Lua,
-    bufnr: u32,
+    bufnr: u16,
     ns_id: i32,
     line_start: u32,
     line_end: i32,
@@ -34,19 +34,19 @@ pub fn buf_clear_namespace(
 /// Binding to `vim.api.nvim_buf_set_extmark`.
 pub fn buf_set_extmark(
     lua: &Lua,
-    bufnr: u32,
-    ns_id: u32,
+    bufnr: u16,
+    ns_id: u16,
     row: u32,
     col: u32,
     opts: Table,
-) -> LuaResult<u32> {
+) -> LuaResult<u16> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_buf_set_extmark")?
         .call((bufnr, ns_id, row, col, opts))
 }
 
 /// Binding to `vim.api.nvim_create_namespace`.
-pub fn create_namespace(lua: &Lua, name: &'static str) -> LuaResult<u32> {
+pub fn create_namespace(lua: &Lua, name: &'static str) -> LuaResult<u16> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_create_namespace")?
         .call(name)

--- a/compleet-client/src/bindings/api/global.rs
+++ b/compleet-client/src/bindings/api/global.rs
@@ -6,14 +6,14 @@ use mlua::{
 
 // TODO: make `command` accept strings.
 /// Binding to `vim.api.nvim_add_user_command`.
-pub fn add_user_command(
+pub fn create_user_command(
     lua: &Lua,
     name: &str,
     command: LuaFunction,
     opts: Table,
 ) -> LuaResult<()> {
     super::api(lua)?
-        .get::<&str, LuaFunction>("nvim_add_user_command")?
+        .get::<&str, LuaFunction>("nvim_create_user_command")?
         .call((name, command, opts))
 }
 

--- a/compleet-client/src/bindings/api/global.rs
+++ b/compleet-client/src/bindings/api/global.rs
@@ -5,7 +5,7 @@ use mlua::{
 };
 
 // TODO: make `command` accept strings.
-/// Binding to `vim.api.nvim_add_user_command`.
+/// Binding to `vim.api.nvim_create_user_command`.
 pub fn create_user_command(
     lua: &Lua,
     name: &str,
@@ -18,7 +18,7 @@ pub fn create_user_command(
 }
 
 /// Binding to `vim.api.nvim_create_buf`.
-pub fn create_buf(lua: &Lua, listed: bool, scratch: bool) -> LuaResult<u32> {
+pub fn create_buf(lua: &Lua, listed: bool, scratch: bool) -> LuaResult<u16> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_create_buf")?
         .call((listed, scratch))
@@ -46,7 +46,7 @@ pub fn echo(
 }
 
 /// Binding to `vim.api.nvim_get_current_buf`
-pub fn get_current_buf(lua: &Lua) -> LuaResult<u32> {
+pub fn get_current_buf(lua: &Lua) -> LuaResult<u16> {
     super::api(lua)?.get::<&str, LuaFunction>("nvim_get_current_buf")?.call(())
 }
 
@@ -115,7 +115,7 @@ pub fn replace_termcodes(
 /// Binding to `vim.api.nvim_set_hl`.
 pub fn set_hl(
     lua: &Lua,
-    ns_id: u32,
+    ns_id: u16,
     name: &str,
     opts: Table,
 ) -> LuaResult<()> {

--- a/compleet-client/src/bindings/api/global.rs
+++ b/compleet-client/src/bindings/api/global.rs
@@ -98,6 +98,11 @@ pub fn notify<S: AsRef<str>>(
     ))
 }
 
+/// Binding to `vim.api.nvim_list_tabpages
+pub fn list_tabpages(lua: &Lua) -> LuaResult<Table> {
+    super::api(lua)?.get::<_, LuaFunction>("nvim_list_tabpages")?.call(())
+}
+
 #[allow(dead_code)]
 /// Binding to `vim.api.nvim_replace_termcodes`
 pub fn replace_termcodes(

--- a/compleet-client/src/bindings/api/win_config.rs
+++ b/compleet-client/src/bindings/api/win_config.rs
@@ -6,10 +6,10 @@ use mlua::{
 /// Binding to `vim.api.nvim_open_win`.
 pub fn open_win(
     lua: &Lua,
-    bufnr: u32,
+    bufnr: u16,
     enter: bool,
     config: Table,
-) -> LuaResult<u32> {
+) -> LuaResult<u16> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_open_win")?
         .call((bufnr, enter, config))
@@ -17,14 +17,14 @@ pub fn open_win(
 
 #[allow(dead_code)]
 /// Binding to `vim.api.nvim_win_get_config`.
-pub fn win_get_config(lua: &Lua, winid: u32) -> LuaResult<Table> {
+pub fn win_get_config(lua: &Lua, winid: u16) -> LuaResult<Table> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_win_get_config")?
         .call(winid)
 }
 
 /// Binding to `vim.api.nvim_win_set_config`.
-pub fn win_set_config(lua: &Lua, winid: u32, config: Table) -> LuaResult<()> {
+pub fn win_set_config(lua: &Lua, winid: u16, config: Table) -> LuaResult<()> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_win_set_config")?
         .call((winid, config))

--- a/compleet-client/src/bindings/api/window.rs
+++ b/compleet-client/src/bindings/api/window.rs
@@ -14,7 +14,7 @@ pub fn win_close(lua: &Lua, winid: u32, force: bool) -> LuaResult<()> {
 }
 
 /// Binding to `vim.api.nvim_win_get_cursor`
-pub fn win_get_cursor(lua: &Lua, winid: u32) -> LuaResult<(u32, u32)> {
+pub fn win_get_cursor(lua: &Lua, winid: u16) -> LuaResult<(u16, u16)> {
     let position = super::api(lua)?
         .get::<&str, LuaFunction>("nvim_win_get_cursor")?
         .call::<_, Table>(winid)?;
@@ -43,14 +43,14 @@ pub fn win_get_position(lua: &Lua, winid: u32) -> LuaResult<(u16, u16)> {
 }
 
 /// Binding to `vim.api.nvim_win_get_width`
-pub fn win_get_width(lua: &Lua, winid: u32) -> LuaResult<u32> {
+pub fn win_get_width(lua: &Lua, winid: u16) -> LuaResult<u16> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_win_get_width")?
         .call(winid)
 }
 
 /// Binding to `vim.api.nvim_win_get_width`
-pub fn win_get_height(lua: &Lua, winid: u32) -> LuaResult<u32> {
+pub fn win_get_height(lua: &Lua, winid: u16) -> LuaResult<u16> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_win_get_height")?
         .call(winid)

--- a/compleet-client/src/bindings/api/window.rs
+++ b/compleet-client/src/bindings/api/window.rs
@@ -7,7 +7,7 @@ use mlua::{
 };
 
 /// Binding to `vim.api.nvim_win_close`.
-pub fn win_close(lua: &Lua, winid: u32, force: bool) -> LuaResult<()> {
+pub fn win_close(lua: &Lua, winid: u16, force: bool) -> LuaResult<()> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_win_close")?
         .call((winid, force))
@@ -25,7 +25,7 @@ pub fn win_get_cursor(lua: &Lua, winid: u16) -> LuaResult<(u16, u16)> {
 /// Binding to `vim.api.nvim_win_get_option`
 pub fn win_get_option<'lua, V: FromLua<'lua>>(
     lua: &'lua Lua,
-    winid: u32,
+    winid: u16,
     name: &str,
 ) -> LuaResult<V> {
     super::api(lua)?
@@ -34,7 +34,7 @@ pub fn win_get_option<'lua, V: FromLua<'lua>>(
 }
 
 /// Binding to `vim.api.nvim_win_get_position`
-pub fn win_get_position(lua: &Lua, winid: u32) -> LuaResult<(u16, u16)> {
+pub fn win_get_position(lua: &Lua, winid: u16) -> LuaResult<(u16, u16)> {
     let position = super::api(lua)?
         .get::<&str, LuaFunction>("nvim_win_get_position")?
         .call::<_, Table>(winid)?;
@@ -57,14 +57,14 @@ pub fn win_get_height(lua: &Lua, winid: u16) -> LuaResult<u16> {
 }
 
 /// Binding to `vim.api.nvim_win_hide`.
-pub fn win_hide(lua: &Lua, winid: u32) -> LuaResult<()> {
+pub fn win_hide(lua: &Lua, winid: u16) -> LuaResult<()> {
     super::api(lua)?.get::<&str, LuaFunction>("nvim_win_hide")?.call(winid)
 }
 
 /// Binding to `vim.api.nvim_win_set_cursor`
 pub fn win_set_cursor(
     lua: &Lua,
-    winid: u32,
+    winid: u16,
     row: u32,
     col: u32,
 ) -> LuaResult<()> {
@@ -76,7 +76,7 @@ pub fn win_set_cursor(
 /// Binding to `vim.api.nvim_win_set_option`
 pub fn win_set_option<'lua, V: ToLua<'lua>>(
     lua: &'lua Lua,
-    winid: u32,
+    winid: u16,
     name: &str,
     value: V,
 ) -> LuaResult<()> {

--- a/compleet-client/src/bindings/api/window.rs
+++ b/compleet-client/src/bindings/api/window.rs
@@ -65,8 +65,8 @@ pub fn win_hide(lua: &Lua, winid: u16) -> LuaResult<()> {
 pub fn win_set_cursor(
     lua: &Lua,
     winid: u16,
-    row: u32,
-    col: u32,
+    row: u16,
+    col: u16,
 ) -> LuaResult<()> {
     super::api(lua)?
         .get::<&str, LuaFunction>("nvim_win_set_cursor")?

--- a/compleet-client/src/bindings/fn/fn.rs
+++ b/compleet-client/src/bindings/fn/fn.rs
@@ -16,7 +16,16 @@ pub fn has(lua: &Lua, feature: &str) -> LuaResult<bool> {
     Ok(bit == 1)
 }
 
-/// Binding to `vim.fn.screenrow`.
-pub fn screenrow(lua: &Lua) -> LuaResult<u16> {
-    self::r#fn(lua)?.get::<_, LuaFunction>("screenrow")?.call(())
+/// Binding to `vim.fn.screenpos
+pub fn screenpos(lua: &Lua, row: u16, col: u16) -> LuaResult<(u16, u16)> {
+    let pos = self::r#fn(lua)?
+        .get::<_, LuaFunction>("screenpos")?
+        .call::<_, Table>((0, row, col + 1))?;
+
+    Ok((pos.get::<_, u16>("row")?, pos.get::<_, u16>("col")? - 1))
+}
+
+/// Binding to `vim.fn.winlayout
+pub fn winlayout(lua: &Lua) -> LuaResult<Table> {
+    self::r#fn(lua)?.get::<_, LuaFunction>("winlayout")?.call::<_, Table>(())
 }

--- a/compleet-client/src/bindings/fn/fn.rs
+++ b/compleet-client/src/bindings/fn/fn.rs
@@ -16,18 +16,11 @@ pub fn has(lua: &Lua, feature: &str) -> LuaResult<bool> {
     Ok(bit == 1)
 }
 
-/// Binding to `vim.fn.screenrow`
-pub fn screenrow(lua: &Lua) -> LuaResult<u16> {
-    Ok(self::r#fn(lua)?
-        .get::<_, LuaFunction>("screenrow")?
-        .call::<_, u16>(())?)
-}
-
 /// Binding to `vim.fn.screenpos`
-pub fn screencol(lua: &Lua) -> LuaResult<u16> {
+pub fn screenpos(lua: &Lua, row: u16, col: u16) -> LuaResult<Table> {
     Ok(self::r#fn(lua)?
-        .get::<_, LuaFunction>("screencol")?
-        .call::<_, u16>(())?)
+        .get::<_, LuaFunction>("screenpos")?
+        .call::<_, Table>((0, row, col))?)
 }
 
 /// Binding to `vim.fn.winlayout`

--- a/compleet-client/src/bindings/fn/fn.rs
+++ b/compleet-client/src/bindings/fn/fn.rs
@@ -16,16 +16,21 @@ pub fn has(lua: &Lua, feature: &str) -> LuaResult<bool> {
     Ok(bit == 1)
 }
 
-/// Binding to `vim.fn.screenpos
-pub fn screenpos(lua: &Lua, row: u16, col: u16) -> LuaResult<(u16, u16)> {
-    let pos = self::r#fn(lua)?
-        .get::<_, LuaFunction>("screenpos")?
-        .call::<_, Table>((0, row, col + 1))?;
-
-    Ok((pos.get::<_, u16>("row")?, pos.get::<_, u16>("col")? - 1))
+/// Binding to `vim.fn.screenrow`
+pub fn screenrow(lua: &Lua) -> LuaResult<u16> {
+    Ok(self::r#fn(lua)?
+        .get::<_, LuaFunction>("screenrow")?
+        .call::<_, u16>(())?)
 }
 
-/// Binding to `vim.fn.winlayout
+/// Binding to `vim.fn.screenpos`
+pub fn screencol(lua: &Lua) -> LuaResult<u16> {
+    Ok(self::r#fn(lua)?
+        .get::<_, LuaFunction>("screencol")?
+        .call::<_, u16>(())?)
+}
+
+/// Binding to `vim.fn.winlayout`
 pub fn winlayout(lua: &Lua) -> LuaResult<Table> {
     self::r#fn(lua)?.get::<_, LuaFunction>("winlayout")?.call::<_, Table>(())
 }

--- a/compleet-client/src/channel/channel.rs
+++ b/compleet-client/src/channel/channel.rs
@@ -24,7 +24,7 @@ use crate::{bindings::nvim, state::State, ui};
 #[derive(Debug)]
 struct Msg {
     completions: Completions,
-    changedtick: u32,
+    changedtick: u16,
     num_sources: u8,
 }
 
@@ -58,7 +58,7 @@ impl Channel {
 
         // TODO: refactor from here --
         let cloned = state.clone();
-        let ctick = Arc::new(Mutex::new(0u32));
+        let ctick = Arc::new(Mutex::new(0u16));
         let count = Arc::new(Mutex::new(0u8));
 
         let callback = lua.create_function_mut(move |lua, ()| {
@@ -150,7 +150,7 @@ impl Channel {
     pub fn fetch_completions(
         &mut self,
         cursor: Arc<Cursor>,
-        changedtick: u32,
+        changedtick: u16,
     ) {
         let num_sources = u8::try_from(self.sources.len()).unwrap();
         for source in &self.sources {

--- a/compleet-client/src/channel/channel.rs
+++ b/compleet-client/src/channel/channel.rs
@@ -24,7 +24,7 @@ use crate::{bindings::nvim, state::State, ui};
 #[derive(Debug)]
 struct Msg {
     completions: Completions,
-    changedtick: u16,
+    changedtick: u32,
     num_sources: u8,
 }
 
@@ -58,7 +58,7 @@ impl Channel {
 
         // TODO: refactor from here --
         let cloned = state.clone();
-        let ctick = Arc::new(Mutex::new(0u16));
+        let ctick = Arc::new(Mutex::new(0u32));
         let count = Arc::new(Mutex::new(0u8));
 
         let callback = lua.create_function_mut(move |lua, ()| {
@@ -150,7 +150,7 @@ impl Channel {
     pub fn fetch_completions(
         &mut self,
         cursor: Arc<Cursor>,
-        changedtick: u16,
+        changedtick: u32,
     ) {
         let num_sources = u8::try_from(self.sources.len()).unwrap();
         for source in &self.sources {

--- a/compleet-client/src/channel/on_bytes.rs
+++ b/compleet-client/src/channel/on_bytes.rs
@@ -9,7 +9,7 @@ pub fn on_bytes(
     lua: &Lua,
     state: &mut State,
     bufnr: u16,
-    changedtick: u16,
+    changedtick: u32,
     start_row: u16,
     start_col: u16,
     rows_deleted: u16,

--- a/compleet-client/src/channel/on_bytes.rs
+++ b/compleet-client/src/channel/on_bytes.rs
@@ -8,7 +8,7 @@ use crate::state::State;
 pub fn on_bytes(
     lua: &Lua,
     state: &mut State,
-    bufnr: u32,
+    bufnr: u16,
     changedtick: u32,
     start_row: u32,
     start_col: u32,

--- a/compleet-client/src/channel/on_bytes.rs
+++ b/compleet-client/src/channel/on_bytes.rs
@@ -9,13 +9,13 @@ pub fn on_bytes(
     lua: &Lua,
     state: &mut State,
     bufnr: u16,
-    changedtick: u32,
-    start_row: u32,
-    start_col: u32,
-    rows_deleted: u32,
-    bytes_deleted: u32,
-    rows_added: u32,
-    bytes_added: u32,
+    changedtick: u16,
+    start_row: u16,
+    start_col: u16,
+    rows_deleted: u16,
+    bytes_deleted: u16,
+    rows_added: u16,
+    bytes_added: u16,
 ) -> LuaResult<Option<bool>> {
     // TODO: remove after https://github.com/neovim/neovim/issues/17874.
     // If this buffer is queued to be detached we return `true`, as explained
@@ -76,12 +76,12 @@ pub fn on_bytes(
     Ok(None)
 }
 
-fn get_current_line(lua: &Lua, current_row: u32) -> LuaResult<String> {
+fn get_current_line(lua: &Lua, current_row: u16) -> LuaResult<String> {
     let current_line = api::buf_get_lines(
         lua,
         0,
-        current_row,
-        (current_row + 1).try_into().unwrap(),
+        current_row as i32,
+        current_row  as i32 + 1,
         false,
     )?
     .into_iter()

--- a/compleet-client/src/commands/compleet_start.rs
+++ b/compleet-client/src/commands/compleet_start.rs
@@ -54,7 +54,7 @@ pub fn attach_current(lua: &Lua, state: &mut State) -> LuaResult<()> {
     // If this buffer was queued to be detached from buffer update events (the
     // ones setup by `nvim_buf_attach`, not autocommands) now it no longer
     // needs to.
-    state.buffers_to_be_detached.retain(|&b| b != current.number);
+    state.buffers_to_be_detached.retain(|&b| b != current.bufnr);
 
     // Set the the augroup if it wasn't already set.
     if !state.augroup.is_set() {

--- a/compleet-client/src/commands/compleet_start.rs
+++ b/compleet-client/src/commands/compleet_start.rs
@@ -54,7 +54,7 @@ pub fn attach_current(lua: &Lua, state: &mut State) -> LuaResult<()> {
     // If this buffer was queued to be detached from buffer update events (the
     // ones setup by `nvim_buf_attach`, not autocommands) now it no longer
     // needs to.
-    state.buffers_to_be_detached.retain(|&b| b != current.bufnr);
+    state.buffers_to_be_detached.retain(|&b| b != current.number);
 
     // Set the the augroup if it wasn't already set.
     if !state.augroup.is_set() {

--- a/compleet-client/src/commands/compleet_stop.rs
+++ b/compleet-client/src/commands/compleet_stop.rs
@@ -16,7 +16,7 @@ pub fn detach_all(lua: &Lua, state: &mut State) -> LuaResult<()> {
     // Move all the buffer numbers from the `attached_buffers` vector to
     // `buffers_to_be_detached`.
     state.buffers_to_be_detached.extend::<Vec<u16>>(
-        state.attached_buffers.iter().map(|b| b.bufnr).collect(),
+        state.attached_buffers.iter().map(|b| b.number).collect(),
     );
 
     // Clear the vector of attached buffers.
@@ -50,7 +50,7 @@ pub fn detach_current(lua: &Lua, state: &mut State) -> LuaResult<()> {
     // detached.
     state.attached_buffers.retain(|b| b != &current);
     // TODO: remove after https://github.com/neovim/neovim/issues/17874.
-    state.buffers_to_be_detached.push(current.bufnr);
+    state.buffers_to_be_detached.push(current.number);
 
     // Delete all the buffer-local autocommands on this buffer.
     state.augroup.clear_local(lua, &current)?;

--- a/compleet-client/src/commands/compleet_stop.rs
+++ b/compleet-client/src/commands/compleet_stop.rs
@@ -15,8 +15,8 @@ pub fn detach_all(lua: &Lua, state: &mut State) -> LuaResult<()> {
     // TODO: remove after https://github.com/neovim/neovim/issues/17874.
     // Move all the buffer numbers from the `attached_buffers` vector to
     // `buffers_to_be_detached`.
-    state.buffers_to_be_detached.extend::<Vec<u32>>(
-        state.attached_buffers.iter().map(|b| b.number).collect(),
+    state.buffers_to_be_detached.extend::<Vec<u16>>(
+        state.attached_buffers.iter().map(|b| b.bufnr).collect(),
     );
 
     // Clear the vector of attached buffers.
@@ -50,7 +50,7 @@ pub fn detach_current(lua: &Lua, state: &mut State) -> LuaResult<()> {
     // detached.
     state.attached_buffers.retain(|b| b != &current);
     // TODO: remove after https://github.com/neovim/neovim/issues/17874.
-    state.buffers_to_be_detached.push(current.number);
+    state.buffers_to_be_detached.push(current.bufnr);
 
     // Delete all the buffer-local autocommands on this buffer.
     state.augroup.clear_local(lua, &current)?;

--- a/compleet-client/src/commands/setup.rs
+++ b/compleet-client/src/commands/setup.rs
@@ -36,8 +36,8 @@ pub fn setup(lua: &Lua, state: &Rc<RefCell<State>>) -> LuaResult<()> {
 
     let opts = lua.create_table_from([("bang", true)])?;
 
-    api::add_user_command(lua, "CompleetStart", start, opts.clone())?;
-    api::add_user_command(lua, "CompleetStop", stop, opts)?;
+    api::create_user_command(lua, "CompleetStart", start, opts.clone())?;
+    api::create_user_command(lua, "CompleetStop", stop, opts)?;
 
     Ok(())
 }

--- a/compleet-client/src/mappings/insert_completion.rs
+++ b/compleet-client/src/mappings/insert_completion.rs
@@ -28,9 +28,9 @@ pub fn insert_completion(
     // event loop.
 
     let insert_completion = lua
-        .create_function(move |lua, (row, col, text): (u32, u32, String)| {
+        .create_function(move |lua, (row, col, text): (u16, u16, String)| {
             api::buf_set_text(lua, 0, row, col, row, col, vec![text])?;
-            api::win_set_cursor(lua, 0, row + 1, end_column as u32)?;
+            api::win_set_cursor(lua, 0, row + 1, end_column as u16)?;
             Ok(())
         })?
         .bind((cursor.row, cursor.bytes, text_to_insert.to_string()))?;

--- a/compleet-client/src/state.rs
+++ b/compleet-client/src/state.rs
@@ -19,10 +19,10 @@ pub struct State {
     pub buffers_to_be_detached: Vec<u16>,
 
     /// TODO: docs
-    pub changedtick_last_seen: u32,
+    pub changedtick_last_seen: u16,
 
     /// TODO: docs
-    pub changedtick_last_update: u32,
+    pub changedtick_last_update: u16,
 
     /// The channel used to communicate with the server.
     pub channel: Option<Channel>,

--- a/compleet-client/src/state.rs
+++ b/compleet-client/src/state.rs
@@ -19,10 +19,10 @@ pub struct State {
     pub buffers_to_be_detached: Vec<u16>,
 
     /// TODO: docs
-    pub changedtick_last_seen: u16,
+    pub changedtick_last_seen: u32,
 
     /// TODO: docs
-    pub changedtick_last_update: u16,
+    pub changedtick_last_update: u32,
 
     /// The channel used to communicate with the server.
     pub channel: Option<Channel>,

--- a/compleet-client/src/state.rs
+++ b/compleet-client/src/state.rs
@@ -16,7 +16,7 @@ pub struct State {
     pub augroup: Augroup,
 
     // TODO: remove after https://github.com/neovim/neovim/issues/17874.
-    pub buffers_to_be_detached: Vec<u32>,
+    pub buffers_to_be_detached: Vec<u16>,
 
     /// TODO: docs
     pub changedtick_last_seen: u32,

--- a/compleet-client/src/ui/buffer.rs
+++ b/compleet-client/src/ui/buffer.rs
@@ -6,19 +6,19 @@ use crate::bindings::api;
 
 #[derive(Debug, PartialEq)]
 pub struct Buffer {
-    pub number: u32,
+    pub bufnr: u16,
 }
 
 impl Display for Buffer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.number.to_string())
+        f.write_str(&self.bufnr.to_string())
     }
 }
 
 impl Buffer {
     /// Returns the current buffer.
     pub fn get_current(lua: &Lua) -> LuaResult<Self> {
-        Ok(Self { number: api::get_current_buf(lua)? })
+        Ok(Self { bufnr: api::get_current_buf(lua)? })
     }
 
     /// Get a buffer-local option.
@@ -27,7 +27,7 @@ impl Buffer {
         lua: &'lua Lua,
         name: &str,
     ) -> LuaResult<V> {
-        api::buf_get_option::<V>(lua, self.number, name)
+        api::buf_get_option::<V>(lua, self.bufnr, name)
     }
 
     /// Calls `vim.api.nvim_buf_attach` on the buffer with the `on_bytes`
@@ -38,6 +38,6 @@ impl Buffer {
             ("on_bytes", LuaValue::Function(on_bytes)),
         ])?;
 
-        api::buf_attach(lua, self.number, false, opts)
+        api::buf_attach(lua, self.bufnr, false, opts)
     }
 }

--- a/compleet-client/src/ui/buffer.rs
+++ b/compleet-client/src/ui/buffer.rs
@@ -6,19 +6,19 @@ use crate::bindings::api;
 
 #[derive(Debug, PartialEq)]
 pub struct Buffer {
-    pub bufnr: u16,
+    pub number: u16,
 }
 
 impl Display for Buffer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.bufnr.to_string())
+        f.write_str(&self.number.to_string())
     }
 }
 
 impl Buffer {
     /// Returns the current buffer.
     pub fn get_current(lua: &Lua) -> LuaResult<Self> {
-        Ok(Self { bufnr: api::get_current_buf(lua)? })
+        Ok(Self { number: api::get_current_buf(lua)? })
     }
 
     /// Get a buffer-local option.
@@ -27,7 +27,7 @@ impl Buffer {
         lua: &'lua Lua,
         name: &str,
     ) -> LuaResult<V> {
-        api::buf_get_option::<V>(lua, self.bufnr, name)
+        api::buf_get_option::<V>(lua, self.number, name)
     }
 
     /// Calls `vim.api.nvim_buf_attach` on the buffer with the `on_bytes`
@@ -38,6 +38,6 @@ impl Buffer {
             ("on_bytes", LuaValue::Function(on_bytes)),
         ])?;
 
-        api::buf_attach(lua, self.bufnr, false, opts)
+        api::buf_attach(lua, self.number, false, opts)
     }
 }

--- a/compleet-client/src/ui/details.rs
+++ b/compleet-client/src/ui/details.rs
@@ -12,7 +12,7 @@ use crate::settings::ui::details::DetailsSettings;
 pub struct CompletionDetails {
     /// Number of the buffer used to show the completion details. It's created
     /// once in `CompletionDetails::new` and never changes.
-    bufnr: u32,
+    bufnr: u16,
 
     /// Floating window used to show the completion details.
     pub floater: Floater,

--- a/compleet-client/src/ui/floater.rs
+++ b/compleet-client/src/ui/floater.rs
@@ -1,6 +1,6 @@
 use mlua::prelude::{Lua, LuaRegistryKey, LuaResult, LuaValue};
 
-use crate::bindings::{api, r#fn};
+use crate::bindings::api;
 use crate::settings::ui::border::Border;
 
 /// Abstracts Neovim's floating windows (see `:h api-floatwin` for details).
@@ -94,20 +94,20 @@ impl Floater {
     /// called if the floater is open.
     pub fn cols_before_after(&self, lua: &Lua) -> LuaResult<(u16, u16)> {
         let columns = api::get_option::<u16>(lua, "columns")?;
-        let mut col_before = r#fn::screencol(lua)? - 1;
+        let (_, mut cols_before) = crate::utils::get_screen_cursor(lua)?;
 
         let cols_after = columns
-            - (col_before + 1)
+            - (cols_before + 1)
             - self.width
             - if self.border_edges[3] { 1 } else { 0 };
 
         // If the left edge of the border is set there's one less available
         // column before the floater.
-        if col_before > 0 && self.border_edges[2] {
-            col_before -= 1;
+        if cols_before > 0 && self.border_edges[2] {
+            cols_before -= 1;
         }
 
-        Ok((col_before, cols_after))
+        Ok((cols_before, cols_after))
     }
 
     /// Whether the floater is currently open.

--- a/compleet-client/src/ui/floater.rs
+++ b/compleet-client/src/ui/floater.rs
@@ -1,6 +1,6 @@
 use mlua::prelude::{Lua, LuaRegistryKey, LuaResult, LuaValue};
 
-use crate::bindings::api;
+use crate::bindings::{api, r#fn};
 use crate::settings::ui::border::Border;
 
 /// Abstracts Neovim's floating windows (see `:h api-floatwin` for details).
@@ -94,7 +94,7 @@ impl Floater {
     /// called if the floater is open.
     pub fn cols_before_after(&self, lua: &Lua) -> LuaResult<(u16, u16)> {
         let columns = api::get_option::<u16>(lua, "columns")?;
-        let (_, mut col_before) = crate::utils::get_screen_cursor(lua)?;
+        let mut col_before = r#fn::screencol(lua)? - 1;
 
         let cols_after = columns
             - (col_before + 1)

--- a/compleet-client/src/ui/floater.rs
+++ b/compleet-client/src/ui/floater.rs
@@ -93,29 +93,21 @@ impl Floater {
     /// considering the left and right edges of its border. Should only be
     /// called if the floater is open.
     pub fn cols_before_after(&self, lua: &Lua) -> LuaResult<(u16, u16)> {
-        let cols_total = api::get_option::<u16>(lua, "columns")?;
+        let columns = api::get_option::<u16>(lua, "columns")?;
+        let (_, mut col_before) = crate::utils::get_screen_cursor(lua)?;
 
-        let winid = self.id.expect("The floater is open so it has an id");
-
-        // BUG: the `col` of `win_get_position` is sometimes bigger that the
-        // total number of columns, causing the following subtractions to
-        // overflow.
-        //
-        // TODO: Open an issue upstream.
-        let mut cols_before = api::win_get_position(lua, winid)?.1;
-
-        let cols_after = cols_total
-            - cols_before
+        let cols_after = columns
+            - (col_before + 1)
             - self.width
             - if self.border_edges[3] { 1 } else { 0 };
 
         // If the left edge of the border is set there's one less available
         // column before the floater.
-        if cols_before > 0 && self.border_edges[2] {
-            cols_before -= 1;
+        if col_before > 0 && self.border_edges[2] {
+            col_before -= 1;
         }
 
-        Ok((cols_before, cols_after))
+        Ok((col_before, cols_after))
     }
 
     /// Whether the floater is currently open.

--- a/compleet-client/src/ui/floater.rs
+++ b/compleet-client/src/ui/floater.rs
@@ -16,10 +16,10 @@ pub struct Floater {
     border_style_key: Option<LuaRegistryKey>,
 
     /// The number of the buffer this floating window should contain.
-    bufnr: u32,
+    bufnr: u16,
 
     /// The window id of the floater, or `None` if it's currently closed.
-    pub id: Option<u32>,
+    pub id: Option<u16>,
 
     #[allow(dead_code)]
     /// The height of the floater in terminal rows, **not** including the
@@ -38,13 +38,13 @@ pub struct Floater {
 /// floater.
 pub enum RelativeTo {
     Cursor(i32, i32),
-    Floater(u32, i32, i32),
+    Floater(u16, i32, i32),
 }
 
 impl Floater {
     pub fn new(
         lua: &Lua,
-        bufnr: u32,
+        bufnr: u16,
         border: &Border,
         hl_groups: Vec<(&'static str, &'static str)>,
     ) -> LuaResult<Self> {

--- a/compleet-client/src/ui/hint.rs
+++ b/compleet-client/src/ui/hint.rs
@@ -10,7 +10,7 @@ pub struct CompletionHint {
     pub is_visible: bool,
 
     /// The namespace id associated to the completion hint.
-    nsid: u32,
+    nsid: u16,
 }
 
 impl CompletionHint {

--- a/compleet-client/src/ui/menu.rs
+++ b/compleet-client/src/ui/menu.rs
@@ -1,7 +1,6 @@
 use std::cmp;
 use std::num::NonZeroUsize;
 
-use mlua::Table;
 use mlua::{prelude::LuaResult, Lua};
 use sources::completion::Completions;
 
@@ -14,13 +13,13 @@ use crate::settings::ui::menu::MenuSettings;
 pub struct CompletionMenu {
     /// Number of the buffer used to show the completions. It's created on
     /// once in `CompletionMenu::new` and never changes.
-    pub bufnr: u32,
+    pub bufnr: u16,
 
     /// Floating window used to show the completion menu.
     pub floater: Floater,
 
     /// TODO: docs
-    mc_nsid: u32,
+    mc_nsid: u16,
 
     /// The index of the currently selected completion item, or `None` if no
     /// completion is selected.

--- a/compleet-client/src/ui/menu.rs
+++ b/compleet-client/src/ui/menu.rs
@@ -178,7 +178,8 @@ fn rows_above_below_cursor(lua: &Lua) -> LuaResult<(u16, u16)> {
     let cmdheight = api::get_option::<u8>(lua, "cmdheight")?;
     let laststatus = api::get_option::<u8>(lua, "laststatus")?;
     let showtabline = api::get_option::<u8>(lua, "showtabline")?;
-    let screenrow = r#fn::screenrow(lua)?;
+
+    let (screenrow, _) = crate::utils::get_screen_cursor(lua)?;
 
     let statuslineoffset: u8 = match laststatus {
         0 => 0,
@@ -209,10 +210,11 @@ fn rows_above_below_cursor(lua: &Lua) -> LuaResult<(u16, u16)> {
         _ => 1,
     };
 
-    let row_above = screenrow - (tablineoffset + 1) as u16;
-    let row_below = lines
-        - row_above
+    let rows_above = screenrow - (tablineoffset + 1) as u16;
+
+    let rows_below = lines
+        - rows_above
         - (tablineoffset + statuslineoffset + cmdheight + 1) as u16;
 
-    Ok((row_above, row_below))
+    Ok((rows_above, rows_below))
 }

--- a/compleet-client/src/ui/update.rs
+++ b/compleet-client/src/ui/update.rs
@@ -11,7 +11,7 @@ pub fn update(
     lua: &Lua,
     state: &mut State,
     new: Completions,
-    changedtick: u32,
+    changedtick: u16,
     is_last: bool,
 ) -> LuaResult<()> {
     // A source sending no completions should usually cause no UI update. The
@@ -92,7 +92,7 @@ pub fn update(
             api::win_set_cursor(
                 lua,
                 winid,
-                u32::try_from(index + 1).unwrap(),
+                index as u16 + 1,
                 0,
             )?;
 

--- a/compleet-client/src/ui/update.rs
+++ b/compleet-client/src/ui/update.rs
@@ -11,7 +11,7 @@ pub fn update(
     lua: &Lua,
     state: &mut State,
     new: Completions,
-    changedtick: u16,
+    changedtick: u32,
     is_last: bool,
 ) -> LuaResult<()> {
     // A source sending no completions should usually cause no UI update. The

--- a/compleet-client/src/utils.rs
+++ b/compleet-client/src/utils.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 
 use mlua::prelude::{Lua, LuaResult};
 
-use crate::bindings::api;
+use crate::bindings::{api, r#fn};
 use crate::constants::{hlgroups::messages, MSG_TAG};
 
 /// Echoes an error message.
@@ -77,6 +77,14 @@ fn to_highlighted_chunks(
     }
 
     chunks
+}
+
+pub fn get_screen_cursor(lua: &Lua) -> LuaResult<(u16, u16)> {
+    let (row, col) = api::win_get_cursor(lua, 0)?;
+
+    let pos = r#fn::screenpos(lua, row, col + 1)?;
+
+    Ok((pos.get::<_, u16>("row")?, pos.get::<_, u16>("col")? - 1))
 }
 
 #[cfg(test)]

--- a/compleet-client/src/utils.rs
+++ b/compleet-client/src/utils.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 
 use mlua::prelude::{Lua, LuaResult};
 
-use crate::bindings::{api, r#fn};
+use crate::bindings::api;
 use crate::constants::{hlgroups::messages, MSG_TAG};
 
 /// Echoes an error message.
@@ -15,21 +15,14 @@ pub fn echoerr<M: Display>(lua: &Lua, msg: M) -> LuaResult<()> {
 pub fn echowar<M: Display>(lua: &Lua, msg: M) -> LuaResult<()> {
     self::echo(lua, msg.to_string(), messages::WARNING_MSG_TAG)
 }
-///
+
+// TODO: create highlight group
 /// Echoes an info message.
 pub fn echoinfo<M: Display>(lua: &Lua, msg: M) -> LuaResult<()> {
     self::echo(lua, msg.to_string(), messages::INFO_MSG_TAG)
 }
 
-// TODO: create highlight group
-/// Echoes a info message. pub fn echoinfo<M: Display>(lua: &Lua, msg: M) ->
-/// LuaResult<()> { self::echo(lua, msg.to_string(), messages::INFO_MSG_TAG) }
-/// Echoes a nicely highlighted message and adds it to the message history.
-pub fn echo(
-    lua: &Lua,
-    msg: String,
-    hl_group_tag: &'static str,
-) -> LuaResult<()> {
+fn echo(lua: &Lua, msg: String, hl_group_tag: &'static str) -> LuaResult<()> {
     let msg_chunks = to_highlighted_chunks(
         msg,
         vec![(b'`', messages::OPTION_PATH), (b'"', messages::MSG_FIELD)],
@@ -84,12 +77,6 @@ fn to_highlighted_chunks(
     }
 
     chunks
-}
-
-pub fn get_screen_cursor(lua: &Lua) -> LuaResult<(u16, u16)> {
-    let (row, col) = api::win_get_cursor(lua, 0)?;
-
-    Ok(r#fn::screenpos(lua, row, col)?)
 }
 
 #[cfg(test)]

--- a/compleet-client/src/utils.rs
+++ b/compleet-client/src/utils.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 
 use mlua::prelude::{Lua, LuaResult};
 
-use crate::bindings::api;
+use crate::bindings::{api, r#fn};
 use crate::constants::{hlgroups::messages, MSG_TAG};
 
 /// Echoes an error message.
@@ -15,15 +15,21 @@ pub fn echoerr<M: Display>(lua: &Lua, msg: M) -> LuaResult<()> {
 pub fn echowar<M: Display>(lua: &Lua, msg: M) -> LuaResult<()> {
     self::echo(lua, msg.to_string(), messages::WARNING_MSG_TAG)
 }
-
-// TODO: create highlight group
-/// Echoes a info message.
+///
+/// Echoes an info message.
 pub fn echoinfo<M: Display>(lua: &Lua, msg: M) -> LuaResult<()> {
     self::echo(lua, msg.to_string(), messages::INFO_MSG_TAG)
 }
 
+// TODO: create highlight group
+/// Echoes a info message. pub fn echoinfo<M: Display>(lua: &Lua, msg: M) ->
+/// LuaResult<()> { self::echo(lua, msg.to_string(), messages::INFO_MSG_TAG) }
 /// Echoes a nicely highlighted message and adds it to the message history.
-fn echo(lua: &Lua, msg: String, hl_group_tag: &'static str) -> LuaResult<()> {
+pub fn echo(
+    lua: &Lua,
+    msg: String,
+    hl_group_tag: &'static str,
+) -> LuaResult<()> {
     let msg_chunks = to_highlighted_chunks(
         msg,
         vec![(b'`', messages::OPTION_PATH), (b'"', messages::MSG_FIELD)],
@@ -78,6 +84,12 @@ fn to_highlighted_chunks(
     }
 
     chunks
+}
+
+pub fn get_screen_cursor(lua: &Lua) -> LuaResult<(u16, u16)> {
+    let (row, col) = api::win_get_cursor(lua, 0)?;
+
+    Ok(r#fn::screenpos(lua, row, col)?)
 }
 
 #[cfg(test)]

--- a/compleet-sources/src/completion.rs
+++ b/compleet-sources/src/completion.rs
@@ -11,7 +11,7 @@ pub struct CompletionItem {
     pub format: String,
 
     /// TODO: docs
-    pub matched_prefix: u32,
+    pub matched_prefix: u16,
 
     /// The number of bytes before the current cursor position that are
     /// matched by the completion item.

--- a/compleet-sources/src/cursor.rs
+++ b/compleet-sources/src/cursor.rs
@@ -4,13 +4,13 @@
 #[derive(Debug, Clone /* Serialize, Deserialize */)]
 pub struct Cursor {
     /// The number of bytes between the start of the line and the cursor.
-    pub bytes: u32,
+    pub bytes: u16,
 
     /// The text in the row the cursor is currently on.
     pub line: String,
 
     /// The row the cursor is currently on.
-    pub row: u32,
+    pub row: u16,
 }
 
 impl Default for Cursor {

--- a/compleet-sources/src/sources/completion_source.rs
+++ b/compleet-sources/src/sources/completion_source.rs
@@ -11,7 +11,7 @@ pub type Sources = Vec<Arc<dyn CompletionSource>>;
 #[async_trait]
 pub trait CompletionSource: Debug + Send + Sync {
     /// Decides whether to attach the source to a buffer.
-    async fn attach(&self, bufnr: u32) -> bool;
+    async fn attach(&self, bufnr: u16) -> bool;
 
     /// Returns the completion results.
     async fn complete(&self, cursor: &Cursor) -> Completions;

--- a/compleet-sources/src/sources/lipsum/lipsum.rs
+++ b/compleet-sources/src/sources/lipsum/lipsum.rs
@@ -20,7 +20,7 @@ impl Default for Lipsum {
 #[async_trait]
 impl CompletionSource for Lipsum {
     // Attach to all buffers.
-    async fn attach(&self, _bufnr: u32) -> bool {
+    async fn attach(&self, _bufnr: u16) -> bool {
         true
     }
 
@@ -42,7 +42,7 @@ impl CompletionSource for Lipsum {
                 ),
                 format: format!(" {word} "),
                 matched_bytes: vec![0..word_pre.len()],
-                matched_prefix: word_pre.len() as u32,
+                matched_prefix: word_pre.len() as u16,
                 source: "Lipsum",
                 text: word.to_string(),
             })

--- a/compleet-sources/src/sources/lsp/lsp.rs
+++ b/compleet-sources/src/sources/lsp/lsp.rs
@@ -39,7 +39,7 @@ returns a `handle` and a `pid`
 
 #[async_trait]
 impl CompletionSource for Lsp {
-    async fn attach(&self, _bufnr: u32) -> bool {
+    async fn attach(&self, _bufnr: u16) -> bool {
         // let clients = nvim.lsp.buf_get_clients(bufnr)?;
         true
     }
@@ -58,7 +58,7 @@ impl CompletionSource for Lsp {
                 details: None,
                 format: format!(" {word_pre} "),
                 matched_bytes: vec![0..word_pre.len()],
-                matched_prefix: word_pre.len() as u32,
+                matched_prefix: word_pre.len() as u16,
                 source: "Lsp",
                 text: self.test.clone(),
             }]


### PR DESCRIPTION
This changes the calculation of available screen space for the positioning of the windows and which also should fix [this](https://github.com/noib3/nvim-compleet/discussions/8#discussioncomment-2492691). It takes into consideration users' `cmdheight`, `laststatus` and `tabline` settings during the calculation.